### PR TITLE
Populate Terms Dropdown Menu in Course Selector and Small Touchups

### DIFF
--- a/bcs-dashboard/src/pages/courseselector/CourseSelector.js
+++ b/bcs-dashboard/src/pages/courseselector/CourseSelector.js
@@ -569,6 +569,10 @@ const useStyles = makeStyles((theme) => ({
   selectEmpty: {
     marginTop: theme.spacing(2),
   },
+  menuPaper: { 
+    // Controls max height of terms dropdown menu found in course selector
+    maxHeight: 400
+  }
 }));
 
 function TermDropDown(props) {
@@ -632,6 +636,7 @@ function TermDropDown(props) {
         onChange={handleChange}
         displayEmpty
         className={classes.selectEmpty}
+        MenuProps={{ classes: { paper: classes.menuPaper } }}
       >
         <MenuItem value="">
           <em>None</em>


### PR DESCRIPTION
The goal of this PR is to:
- Clean up our JSX code for populating menu items within our terms dropdown menu
- Add logic to set default term based on the current user's local computer time
- Add logic to set term to W1, W2, S based on user's current time
- Automatically show all terms +/- 10 years from the current year.
- Made dropdown menu smaller height-wise. (400px)

Thanks @scott-m-king for the help haha.

![image](https://user-images.githubusercontent.com/10675973/121797641-643b9b80-cbd6-11eb-81c0-1e3ca0a934aa.png)
Within our function, TermDropDown:
```
const terms = Object.freeze({
    'W1': { // Sep - Dec
      start: 8,
      end: 11
    },
    'W2': { // Jan - Apr
      start: 0,
      end: 3
    }, 
    'S': { // May  - Aug
      start: 4,
      end: 7
    }
  });
```


![image](https://user-images.githubusercontent.com/10675973/121797653-7ddce300-cbd6-11eb-8df0-9dbcb74cc3bf.png)
Modifying our range is simple:
```
  useEffect(() => {
    const currentYear = new Date().getFullYear();
    const startYear = currentYear - 10;
    const endYear = currentYear + 10;
    const yearArray = [];
    for (let i = startYear; i <= endYear; i++) { 
      for (let currentTerm of Object.keys(terms)) {
        yearArray.push(`${i}${currentTerm}`);
      }
    }
    setTermList(yearArray);
  }, []);
```




