### PR TITLE
Fix Search Component Focus

### DIFF
--- a/bcs-dashboard/src/pages/courseselector/SearchComponent.js
+++ b/bcs-dashboard/src/pages/courseselector/SearchComponent.js
@@ -34,7 +34,7 @@ export default function SearchComponent(props) {
     try {
       document.getElementsByClassName(
         "ui fluid icon input"
-      )[0].children.item("input")
+      ).item('div.ui.fluid.icon.input').children.item('input.prompt')
       .focus();
     } catch (error) {
       console.log("Document failed to select search component. ", error);


### PR DESCRIPTION
**Problem**

Previously, we attempted to focus on a query selector path (i.e., `#root > div.MuiGrid-root.MuiGrid-container.MuiGrid-spacing-xs-6 > div:nth-child(1) > div > div > div > div > div > div:nth-child(1) > div > div.ui.fluid.icon.input > input`). The problem is that this path changes after a number of deploys and is probably the product of other changes to our front-end codebase. This results in the focus breaking from time-to-time and an error message being printed to the console.

**Solution**

Using this line ([here](https://github.com/HelloWorldFam/BCS-Course-Selector//blob/563598e04cdb77a26cd2e144c7dea3ca7b349ff4/bcs-dashboard/src/pages/courseselector/SearchComponent.js#L37)), we select the appropriate box with greater precision. 


...and it works in my local environment!
https://user-images.githubusercontent.com/45858320/124407680-61c1f280-dcf9-11eb-9bdb-426f44ce9969.mp4
